### PR TITLE
add proc "close", and support to extract archives that used file sorting "by type"

### DIFF
--- a/nim7z.nim
+++ b/nim7z.nim
@@ -148,7 +148,9 @@ proc extract*(svnz: SvnzFile, directory: string, skipOuterDirs=false, tempDir: s
       var filePath: string
       if not skipOuterDirs:
         filePath = tempDir / file
-        createDir(filePath.splitPath.head)
+        let dirPath = filePath.splitPath.head
+        if not existsDir(dirPath):
+          createDir(dirPath)
       else:
         filePath = tempDir / file.extractFilename()
       let fp = filePath.open(fmWrite)


### PR DESCRIPTION
- add proc "close". because I want to delete the .7z file after extracting it.
- https://nim-lang.org/download/mingw64.7z cannot be extracted.
written in https://www.7-zip.org/faq.html,
> New versions of 7-Zip (starting from version 15.06) use another file sorting order by default for solid 7z archives.
>Old version of 7-Zip (before version 15.06) used file sorting "by type" ("by extension").
>New version of 7-Zip supports two sorting orders:
> - sorting by name - default order.
> - sorting by type, if 'qs' is specified in Parameters field in "Add to archive" window, (or -mqs switch for command line version). 
